### PR TITLE
Add functools.wraps to log_function_call

### DIFF
--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -34,6 +34,7 @@ parameter `level`.
 
 See the documentation for more information: https://logzero.readthedocs.io
 """
+import functools
 import os
 import sys
 import logging
@@ -421,6 +422,7 @@ def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encod
 
 
 def log_function_call(func):
+    @functools.wraps(func)
     def wrap(*args, **kwargs):
         args_str = ", ".join([str(arg) for arg in args])
         kwargs_str = ", ".join(["%s=%s" % (key, kwargs[key]) for key in kwargs])

--- a/tests/test_logzero.py
+++ b/tests/test_logzero.py
@@ -252,3 +252,14 @@ def test_setup_logger_logfile_custom_loglevel(capsys):
 
     finally:
         temp.close()
+
+
+def test_log_function_call():
+    @logzero.log_function_call
+    def example():
+        """example doc"""
+        pass
+
+    assert example.__name__ == "example"
+    assert example.__doc__ == "example doc"
+


### PR DESCRIPTION
Ensure that the wrapped function 'looks like' the original function.