### PR TITLE
Fix for allowing the FileHandler loglevel to be lower than the SteamHandler loglevel

### DIFF
--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -414,11 +414,13 @@ def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encod
         setattr(rotating_filehandler, LOGZERO_INTERNAL_LOGGER_ATTR, True)
         if loglevel:
             setattr(rotating_filehandler, LOGZERO_INTERNAL_HANDLER_IS_CUSTOM_LOGLEVEL, True)
-
+            if loglevel < _loglevel:
+                logger.setLevel(loglevel)
         # Configure the handler and add it to the logger
         rotating_filehandler.setLevel(loglevel or _loglevel)
         rotating_filehandler.setFormatter(formatter or _formatter or LogFormatter(color=False))
         logger.addHandler(rotating_filehandler)
+
 
 
 def log_function_call(func):

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -143,6 +143,7 @@ def setup_logger(name=None, logfile=None, level=logging.DEBUG, formatter=None, m
         rotating_filehandler.setLevel(fileLoglevel or level)
         rotating_filehandler.setFormatter(formatter or LogFormatter(color=False))
         _logger.addHandler(rotating_filehandler)
+
         if fileLoglevel and fileLoglevel < level:
             _logger.setLevel(fileLoglevel)
 
@@ -416,8 +417,10 @@ def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encod
         setattr(rotating_filehandler, LOGZERO_INTERNAL_LOGGER_ATTR, True)
         if loglevel:
             setattr(rotating_filehandler, LOGZERO_INTERNAL_HANDLER_IS_CUSTOM_LOGLEVEL, True)
+
             if loglevel < _loglevel:
                 logger.setLevel(loglevel)
+
         # Configure the handler and add it to the logger
         rotating_filehandler.setLevel(loglevel or _loglevel)
         rotating_filehandler.setFormatter(formatter or _formatter or LogFormatter(color=False))

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -143,6 +143,8 @@ def setup_logger(name=None, logfile=None, level=logging.DEBUG, formatter=None, m
         rotating_filehandler.setLevel(fileLoglevel or level)
         rotating_filehandler.setFormatter(formatter or LogFormatter(color=False))
         _logger.addHandler(rotating_filehandler)
+        if fileLoglevel and fileLoglevel < level:
+            _logger.setLevel(fileLoglevel)
 
     return _logger
 


### PR DESCRIPTION
This addresses issue #57.
Added a condition to reset the loglevel of the `logger` Object, 
if the loglevel specified for the `RotatingFileHandler` is lower than the loglevel specified before. 
The loglevel of the `logger` will than be set to the loglevel of the ` RotatingFileHandler`.
This is necessary because the loglevel of a `Handler` can only be equal or greater  than the loglevel of the`logger` itself.