### PR TITLE
Fixing: Logfile with lower loglevel than console output

### DIFF
--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -340,7 +340,6 @@ def loglevel(level=logging.DEBUG, update_custom_handlers=False):
     :arg bool update_custom_handlers: If you added custom handlers to this logger and want this to update them too, you need to set `update_custom_handlers` to `True`
     """
 
-
     # Reconfigure existing internal handlers
     for handler in list(logger.handlers):
         if hasattr(handler, LOGZERO_INTERNAL_LOGGER_ATTR) or update_custom_handlers:

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -112,7 +112,7 @@ def setup_logger(name=None, logfile=None, level=logging.DEBUG, formatter=None, m
     """
     _logger = logging.getLogger(name or __name__)
     _logger.propagate = False
-    _logger.setLevel(level)
+    _logger.setLevel(logging.DEBUG)
 
     # Reconfigure existing handlers
     has_stream_handler = False
@@ -339,7 +339,7 @@ def loglevel(level=logging.DEBUG, update_custom_handlers=False):
     :arg int level: Minimum `logging-level <https://docs.python.org/2/library/logging.html#logging-levels>`_ to display (default: `logging.DEBUG`).
     :arg bool update_custom_handlers: If you added custom handlers to this logger and want this to update them too, you need to set `update_custom_handlers` to `True`
     """
-    logger.setLevel(level)
+
 
     # Reconfigure existing internal handlers
     for handler in list(logger.handlers):

--- a/tests/test_logzero.py
+++ b/tests/test_logzero.py
@@ -262,4 +262,3 @@ def test_log_function_call():
 
     assert example.__name__ == "example"
     assert example.__doc__ == "example doc"
-

--- a/tests/test_new_api.py
+++ b/tests/test_new_api.py
@@ -167,7 +167,7 @@ def test_api_logfile_custom_lower_loglevel():
         # If setting a loglevel with logzero.loglevel(..) it will not overwrite
         # the custom loglevel of the file handler even if higher
         logzero.loglevel(logging.INFO)
-        logzero.logger.debug("debug1")
+        logzero.logger.debug("debug2")
         logzero.logger.info("info2")
 
         with open(temp.name) as f:

--- a/tests/test_new_api.py
+++ b/tests/test_new_api.py
@@ -150,3 +150,33 @@ def test_api_logfile_custom_loglevel():
 
     finally:
         temp.close()
+
+
+def test_api_logfile_custom_lower_loglevel():
+    """
+    logzero.logfile(..) should be able to use a custom loglevel
+    """
+    logzero.reset_default_logger()
+    temp = tempfile.NamedTemporaryFile()
+    try:
+        # Set logfile with custom loglevel
+        logzero.logfile(temp.name, loglevel=logging.DEBUG)
+        logzero.logger.debug("debug1")
+        logzero.logger.info("info1")
+
+        # If setting a loglevel with logzero.loglevel(..) it will not overwrite
+        # the custom loglevel of the file handler even if higher
+        logzero.loglevel(logging.INFO)
+        logzero.logger.debug("debug1")
+        logzero.logger.info("info2")
+
+        with open(temp.name) as f:
+            content = f.read()
+            assert "] debug1" in content
+            assert "] info1" in content
+
+            assert "] debug2" in content
+            assert "] info2" in content
+
+    finally:
+        temp.close()


### PR DESCRIPTION
This fixes the issue described in #57. 
To sum it up briefly:
The loglevel of a `Handler` added to a logger object is limited to be equal to or higher than the 
loglevel of the logger object. Previously the logger objects loglevel was always set to the loglevel of
the corresponding `StreamHandler`. This meant that the loglevel a later defined logfile could not be lower.

This 'fix' is the easiest I could come up with and has very minimal changes to the code. It sets the loglevel of the logger object by default to `DEBUG`, the (by default) lowest logging level.