### PR TITLE
Drop Python 3.3 support to allow dependency updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ language: python
 python:
 - 2.6
 - 2.7
-- 3.3
 - 3.4
 - 3.5
 - 3.6

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6 and for PyPy. Check
    https://travis-ci.org/metachris/logzero/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
- Py-Up reports security vulnerabilities for `cryptography` - https://pyup.io/repos/github/metachris/logzero/
- This py-up PR wants to update it: https://github.com/metachris/logzero/pull/122
- The related Travis build reports that `tox` requires Python 3.4+ as well as all other py-up PRs.
https://travis-ci.org/metachris/logzero/jobs/416120355

Could we drop Python 3.3 support? It has reached [end-of-life](https://www.python.org/download/releases/3.3.0). This would also lead to the possibility to update other packages if required _and_ better security.