### PR TITLE
Allow lower loglevel for logfiles (fixes #57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ from logzero import logger
 
 logger.debug("hello")
 logger.info("info")
-logger.warn("warn")
+logger.warning("warn")
 logger.error("error")
 
 # This is how you'd log an exception
@@ -137,7 +137,11 @@ On openSUSE you can install the current version from repos: [python2-logzero](ht
 Development
 -----------
 
-Note: this project is using pytest. CI is run with [Github actions](https://github.com/metachris/logzero/tree/master/.github/workflows).
+Notes:
+
+* Using pytest as test runner
+* CI is run with [Github actions](https://github.com/metachris/logzero/tree/master/.github/workflows).
+* Download stats: https://pepy.tech/project/logzero
 
 ### Getting started
 
@@ -159,6 +163,11 @@ $ make lint
 # Generate the docs (will auto-open in Chrome)
 $ make docs
 ```
+
+**To do**
+
+* CI to publish package to PyPI
+
 
 ---
 

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -113,7 +113,10 @@ def setup_logger(name=None, logfile=None, level=logging.DEBUG, formatter=None, m
     """
     _logger = logging.getLogger(name or __name__)
     _logger.propagate = False
-    _logger.setLevel(level)
+
+    # set the minimum level needed for the logger itself (the lowest handler level)
+    minLevel = fileLoglevel if fileLoglevel and fileLoglevel < level else level
+    _logger.setLevel(minLevel)
 
     # Reconfigure existing handlers
     stderr_stream_handler = None

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -17,7 +17,7 @@ Usage:
 
     logger.debug("hello")
     logger.info("info")
-    logger.warn("warn")
+    logger.warning("warn")
     logger.error("error")
 
 In order to also log to a file, just use `logzero.logfile(..)`:
@@ -337,7 +337,7 @@ reset_default_logger()
 
 def loglevel(level=logging.DEBUG, update_custom_handlers=False):
     """
-    Set the minimum loglevel for the default logger (`logzero.logger`).
+    Set the minimum loglevel for the default logger (`logzero.logger`) and all handlers.
 
     This reconfigures only the internal handlers of the default logger (eg. stream and logfile).
     You can also update the loglevel for custom handlers by using `update_custom_handlers=True`.
@@ -408,22 +408,30 @@ def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encod
     :arg int loglevel: Set a custom loglevel for the file logger, else uses the current global loglevel.
     :arg bool disableStderrLogger: Should the default stderr logger be disabled. Defaults to False.
     """
-    # Step 1: If an internal RotatingFileHandler already exists, remove it
+    # First, remove any existing file logger
     __remove_internal_loggers(logger, disableStderrLogger)
 
-    # Step 2: If wanted, add the RotatingFileHandler now
-    if filename:
-        rotating_filehandler = RotatingFileHandler(filename, mode=mode, maxBytes=maxBytes, backupCount=backupCount, encoding=encoding)
+    # If no filename supplied, all is done
+    if not filename:
+        return
 
-        # Set internal attributes on this handler
-        setattr(rotating_filehandler, LOGZERO_INTERNAL_LOGGER_ATTR, True)
-        if loglevel:
-            setattr(rotating_filehandler, LOGZERO_INTERNAL_HANDLER_IS_CUSTOM_LOGLEVEL, True)
+    # Now add
+    rotating_filehandler = RotatingFileHandler(filename, mode=mode, maxBytes=maxBytes, backupCount=backupCount, encoding=encoding)
 
-        # Configure the handler and add it to the logger
-        rotating_filehandler.setLevel(loglevel or _loglevel)
-        rotating_filehandler.setFormatter(formatter or _formatter or LogFormatter(color=False))
-        logger.addHandler(rotating_filehandler)
+    # Set internal attributes on this handler
+    setattr(rotating_filehandler, LOGZERO_INTERNAL_LOGGER_ATTR, True)
+    if loglevel:
+        setattr(rotating_filehandler, LOGZERO_INTERNAL_HANDLER_IS_CUSTOM_LOGLEVEL, True)
+
+    # Configure the handler and add it to the logger
+    rotating_filehandler.setLevel(loglevel or _loglevel)
+    rotating_filehandler.setFormatter(formatter or _formatter or LogFormatter(color=False))
+    logger.addHandler(rotating_filehandler)
+
+    # If wanting to use a lower loglevel for the file handler, we need to reconfigure the logger level
+    # (note: this won't change the StreamHandler loglevel)
+    if loglevel and loglevel < logger.level:
+        logger.setLevel(loglevel)
 
 
 def __remove_internal_loggers(logger_to_update, disableStderrLogger=True):

--- a/tests/test_logzero.py
+++ b/tests/test_logzero.py
@@ -249,7 +249,7 @@ def test_setup_logger_logfile_custom_loglevel(capsys):
     try:
         logger = logzero.setup_logger(logfile=temp.name, fileLoglevel=logging.WARN)
         logger.info("info1")
-        logger.warn("warn1")
+        logger.warning("warn1")
 
         with open(temp.name) as f:
             content = f.read()
@@ -299,3 +299,25 @@ def test_default_logger_syslog_only(capsys):
     logzero.logger.error('debug')
     out, err = capsys.readouterr()
     assert out == '' and err == ''
+
+
+def test_logfile_lower_loglevel(capsys):
+    """
+    logzero.logfile(..) should work with a lower loglevel than the StreamHandler
+    """
+    logzero.reset_default_logger()
+    temp = tempfile.NamedTemporaryFile()
+    try:
+        logzero.loglevel(level=logging.INFO)
+        logzero.logfile(temp.name, loglevel=logging.DEBUG)
+
+        logzero.logger.debug("debug")
+        logzero.logger.info("info")
+
+        with open(temp.name) as f:
+            content = f.read()
+            assert "] debug" in content
+            assert "] info" in content
+
+    finally:
+        temp.close()

--- a/tests/test_logzero.py
+++ b/tests/test_logzero.py
@@ -321,3 +321,20 @@ def test_logfile_lower_loglevel(capsys):
 
     finally:
         temp.close()
+
+
+def test_logfile_lower_loglevel_setup_logger(capsys):
+    """
+    logzero.setup_logger(..) should work with a lower loglevel than the StreamHandler
+    """
+    temp = tempfile.NamedTemporaryFile()
+    try:
+        logger = logzero.setup_logger(level=logging.INFO, logfile=temp.name, fileLoglevel=logging.DEBUG)
+        logger.debug("debug")
+        logger.info("info")
+        with open(temp.name) as f:
+            content = f.read()
+            assert "] debug" in content
+            assert "] info" in content
+    finally:
+        temp.close()

--- a/tests/test_new_api.py
+++ b/tests/test_new_api.py
@@ -56,7 +56,7 @@ def test_api_loglevel(capsys):
         logzero.logger.info("info1")
         logzero.loglevel(logging.WARN)
         logzero.logger.info("info2")
-        logzero.logger.warn("warn1")
+        logzero.logger.warning("warn1")
 
         with open(temp.name) as f:
             content = f.read()
@@ -81,7 +81,7 @@ def test_api_loglevel_custom_handlers(capsys):
     #     logzero.logger.info("info1")
     #     logzero.loglevel(logging.WARN)
     #     logzero.logger.info("info2")
-    #     logzero.logger.warn("warn1")
+    #     logzero.logger.warning("warn1")
 
     #     with open(temp.name) as f:
     #         content = f.read()
@@ -133,13 +133,13 @@ def test_api_logfile_custom_loglevel():
         # Set logfile with custom loglevel
         logzero.logfile(temp.name, loglevel=logging.WARN)
         logzero.logger.info("info1")
-        logzero.logger.warn("warn1")
+        logzero.logger.warning("warn1")
 
         # If setting a loglevel with logzero.loglevel(..) it will not overwrite
         # the custom loglevel of the file handler
         logzero.loglevel(logging.INFO)
         logzero.logger.info("info2")
-        logzero.logger.warn("warn2")
+        logzero.logger.warning("warn2")
 
         with open(temp.name) as f:
             content = f.read()


### PR DESCRIPTION
See #57 

Previously using a lower loglevel for a file logger than for the stream logger was not possible. This PR fixes it by adjusting the logger level if needed.