### PR TITLE
logzero.json write utf-8 by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,13 @@ jobs:
           pip install -e .
           pip install -r requirements_dev.txt
 
+      - name: Reduce the tests for Python 2
+        run: |
+          if [[ $(python --version 2>&1) =~ 2\. ]]; then
+            echo "Remove python2 incompatible tests"
+            rm tests/test_json.py
+          fi
+
       - name: Run the tests
         run: make test
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -58,3 +58,34 @@ def test_json_logfile(capsys):
 
     finally:
         temp.close()
+
+
+def test_json_encoding(capsys):
+    """
+    see logzero.json(json_ensure_ascii=True)
+    """
+    logzero.reset_default_logger()
+
+    # UTF-8 mode
+    logzero.json(json_ensure_ascii=False)
+    logzero.logger.info('ß')
+    out, err = capsys.readouterr()
+    json.loads(err)  # make sure JSON is valid
+    assert 'ß' in err
+    assert 'u00df' not in err
+
+    # ASCII mode
+    logzero.json(json_ensure_ascii=True)
+    logzero.logger.info('ß')
+    out, err = capsys.readouterr()
+    json.loads(err)  # make sure JSON is valid
+    assert 'u00df' in err
+    assert 'ß' not in err
+
+    # Default JSON mode should be utf-8
+    logzero.json()
+    logzero.logger.info('ß')
+    out, err = capsys.readouterr()
+    json.loads(err)  # make sure JSON is valid
+    assert 'ß' in err
+    assert 'u00df' not in err


### PR DESCRIPTION
See #355 

`JsonFormatter` uses [`json.dumps`](https://docs.python.org/3/library/json.html#json.dumps), which enforces ascii-only encoding by default (`ensure_ascii=True`).

This PR allows the user to choose, with default `ensure_ascii=False`, which means unicode characters will be displayed and saved to the logfile.