### PR TITLE
CONTRIBUTING: upd. Python versions, point away from Travis

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,8 +101,8 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6 and for PyPy. Check
-   https://travis-ci.org/metachris/logzero/pull_requests
+3. The pull request should work for Python 3.6, 3.7, 3.8 and for PyPy. Check
+   `.github/workflows/test.yaml <https://github.com/metachris/logzero/blob/master/.github/workflows/test.yml>`_
    and make sure that the tests pass for all supported Python versions.
 
 Tips


### PR DESCRIPTION
Likely missing a lot of needed changes here, but, I've updated this to only include the Python versions in the github workflows `test.yaml`. (I left in PyPy - no idea if that's appropriate.)