### PR TITLE
Update LogFormatter to allow syslog severity levels, and dateformats of {"iso", "azure"}

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6 and for PyPy. Check
+3. The pull request should work for Python 3.6, 3.7, 3.8, 3.9 and for PyPy. Check
    https://travis-ci.org/metachris/logzero/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Robust and effective logging for Python 2 and 3.
 * Windows color output supported by `colorama`_
 * Robust against str/bytes encoding problems, works with all kinds of character encodings and special characters.
 * Multiple loggers can write to the same logfile (also works across multiple Python files).
+* Any directory structured mentioned is automatically created, if it doesn't exist.
 * Global default logger with `logzero.logger <#i-logzero-logger>`_ and custom loggers with `logzero.setup_logger(..) <#i-logzero-setup-logger>`_.
 * Compatible with Python 2 and 3.
 * All contained in a `single file`_.

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -98,7 +98,7 @@ if os.name == 'nt':
     colorama_init()
 
 
-def setup_logger(name=__name__, logfile=None, level=DEBUG, formatter=None, maxBytes=0, backupCount=0, fileLoglevel=None, disableStderrLogger=False, isRootLogger=False, json=False, json_ensure_ascii=False):
+def setup_logger(name=__name__, logfile=None, level=DEBUG, formatter=None, maxBytes=0, backupCount=0, fileLoglevel=None, log_stream='stderr', isRootLogger=False, json=False, json_ensure_ascii=False):
     """
     Configures and returns a fully configured logger instance, no hassles.
     If a logger with the specified name already exists, it returns the existing instance,
@@ -122,7 +122,7 @@ def setup_logger(name=__name__, logfile=None, level=DEBUG, formatter=None, maxBy
     :arg int maxBytes: Size of the logfile when rollover should occur. Defaults to 0, rollover never occurs.
     :arg int backupCount: Number of backups to keep. Defaults to 0, rollover never occurs.
     :arg int fileLoglevel: Minimum `logging-level <https://docs.python.org/2/library/logging.html#logging-levels>`_ for the file logger (is not set, it will use the loglevel from the ``level`` argument)
-    :arg bool disableStderrLogger: Should the default stderr logger be disabled. Defaults to False.
+    :arg string log_stream: Which standard stream should the log output go to. Can take values of `stderr`, `stdout` or `None`. Defaults to `stderr`.
     :arg bool isRootLogger: If True then returns a root logger. Defaults to False. (see also the `Python docs <https://docs.python.org/3/library/logging.html#logging.getLogger>`_).
     :arg bool json: If True then log in JSON format. Defaults to False. (uses `python-json-logger <https://github.com/madzak/python-json-logger>`_).
     :arg bool json_ensure_ascii: Passed to json.dumps as `ensure_ascii`, default: False (if False: writes utf-8 characters, if True: ascii only representation of special characters - eg. '\u00d6\u00df')
@@ -138,8 +138,13 @@ def setup_logger(name=__name__, logfile=None, level=DEBUG, formatter=None, maxBy
     # Setup default formatter
     _formatter = _get_json_formatter(json_ensure_ascii) if json else formatter or LogFormatter()
 
+    # Ensure the log stream passed by user is valid.
+    if log_stream not in ("stderr", "stdout", None):
+        _logger.warning("Log stream must be one of `'stderr'`, `'stdout'` or `None`. Using `'stderr'`")
+        log_stream = "stderr"
+
     # Reconfigure existing handlers
-    stderr_stream_handler = None
+    std_stream_handler = None
     for handler in list(_logger.handlers):
         if hasattr(handler, LOGZERO_INTERNAL_LOGGER_ATTR):
             if isinstance(handler, logging.FileHandler):
@@ -148,22 +153,25 @@ def setup_logger(name=__name__, logfile=None, level=DEBUG, formatter=None, maxBy
                 _logger.removeHandler(handler)
                 continue
             elif isinstance(handler, logging.StreamHandler):
-                stderr_stream_handler = handler
+                if log_stream is None or log_stream not in std_stream_handler.stream.name:
+                    # remove the std handler (stream_handler) if disabled, or if there is a stream(err/out) mismatch
+                    _logger.removeHandler(handler)
+                    continue
+                else:
+                    # Else, this is the stderr/stdout stream that we need to reconfigure
+                    std_stream_handler = handler
 
         # reconfigure handler
         handler.setLevel(level)
         handler.setFormatter(_formatter)
 
-    # remove the stderr handler (stream_handler) if disabled
-    if disableStderrLogger:
-        if stderr_stream_handler is not None:
-            _logger.removeHandler(stderr_stream_handler)
-    elif stderr_stream_handler is None:
-        stderr_stream_handler = logging.StreamHandler()
-        setattr(stderr_stream_handler, LOGZERO_INTERNAL_LOGGER_ATTR, True)
-        stderr_stream_handler.setLevel(level)
-        stderr_stream_handler.setFormatter(_formatter)
-        _logger.addHandler(stderr_stream_handler)
+    if log_stream is not None and std_stream_handler is None:
+        # This is the block that will be entered for the default logger (ex: `from logzero import logger`)
+        std_stream_handler = logging.StreamHandler(stream=getattr(sys, log_stream))
+        setattr(std_stream_handler, LOGZERO_INTERNAL_LOGGER_ATTR, True)
+        std_stream_handler.setLevel(level)
+        std_stream_handler.setFormatter(_formatter)
+        _logger.addHandler(std_stream_handler)
 
     if logfile:
         rotating_filehandler = RotatingFileHandler(filename=logfile, maxBytes=maxBytes, backupCount=backupCount)
@@ -305,7 +313,7 @@ def _safe_unicode(s):
         return repr(s)
 
 
-def setup_default_logger(logfile=None, level=DEBUG, formatter=None, maxBytes=0, backupCount=0, disableStderrLogger=False):
+def setup_default_logger(logfile=None, level=DEBUG, formatter=None, maxBytes=0, backupCount=0, log_stream='stderr'):
     """
     Deprecated. Use `logzero.loglevel(..)`, `logzero.logfile(..)`, etc.
 
@@ -324,10 +332,10 @@ def setup_default_logger(logfile=None, level=DEBUG, formatter=None, maxBytes=0, 
     :arg Formatter formatter: `Python logging Formatter object <https://docs.python.org/2/library/logging.html#formatter-objects>`_ (by default uses the internal LogFormatter).
     :arg int maxBytes: Size of the logfile when rollover should occur. Defaults to 0, rollover never occurs.
     :arg int backupCount: Number of backups to keep. Defaults to 0, rollover never occurs.
-    :arg bool disableStderrLogger: Should the default stderr logger be disabled. Defaults to False.
+    :arg string log_stream: Which standard stream should the log output go to. Can take values of `stderr`, `stdout` or `None`. Defaults to `stderr`.
     """
     global logger
-    logger = setup_logger(name=LOGZERO_DEFAULT_LOGGER, logfile=logfile, level=level, formatter=formatter, backupCount=backupCount, disableStderrLogger=disableStderrLogger)
+    logger = setup_logger(name=LOGZERO_DEFAULT_LOGGER, logfile=logfile, level=level, formatter=formatter, backupCount=backupCount, log_stream=log_stream)
     return logger
 
 
@@ -350,10 +358,6 @@ def reset_default_logger():
 
     # Resetup
     logger = setup_logger(name=LOGZERO_DEFAULT_LOGGER, logfile=_logfile, level=_loglevel, formatter=_formatter)
-
-
-# Initially setup the default logger
-reset_default_logger()
 
 
 def loglevel(level=DEBUG, update_custom_handlers=False):
@@ -403,7 +407,7 @@ def formatter(formatter, update_custom_handlers=False):
     _formatter = formatter
 
 
-def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encoding=None, loglevel=None, disableStderrLogger=False):
+def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encoding=None, loglevel=None, disable_stream_loggers=False):
     """
     Setup logging to file (using a `RotatingFileHandler <https://docs.python.org/2/library/logging.handlers.html#rotatingfilehandler>`_ internally).
 
@@ -427,10 +431,10 @@ def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encod
     :arg int backupCount: Number of backups to keep. Defaults to 0, rollover never occurs.
     :arg string encoding: Used to open the file with that encoding.
     :arg int loglevel: Set a custom loglevel for the file logger, else uses the current global loglevel.
-    :arg bool disableStderrLogger: Should the default stderr logger be disabled. Defaults to False.
+    :arg bool disable_stream_loggers: should the default stream loggers(stderr/stdout) be disabled? defaults to `True`
     """
     # First, remove any existing file logger
-    __remove_internal_loggers(logger, disableStderrLogger)
+    __remove_internal_loggers(logger, disable_stream_loggers)
 
     # If no filename supplied, all is done
     if not filename:
@@ -455,11 +459,11 @@ def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encod
         logger.setLevel(loglevel)
 
 
-def __remove_internal_loggers(logger_to_update, disableStderrLogger=True):
+def __remove_internal_loggers(logger_to_update, disable_stream_loggers=True):
     """
-    Remove the internal loggers (e.g. stderr logger and file logger) from the specific logger
+    Remove the internal loggers (e.g. stderr/stdout logger and file logger) from the specific logger
     :param logger_to_update: the logger to remove internal loggers from
-    :param disableStderrLogger: should the default stderr logger be disabled? defaults to True
+    :param disable_stream_loggers: should the default stream loggers(stderr/stdout) be disabled? defaults to `True`
     """
     for handler in list(logger_to_update.handlers):
         if hasattr(handler, LOGZERO_INTERNAL_LOGGER_ATTR):
@@ -467,20 +471,20 @@ def __remove_internal_loggers(logger_to_update, disableStderrLogger=True):
                 logger_to_update.removeHandler(handler)
             elif isinstance(handler, SysLogHandler):
                 logger_to_update.removeHandler(handler)
-            elif isinstance(handler, logging.StreamHandler) and disableStderrLogger:
+            elif isinstance(handler, logging.StreamHandler) and disable_stream_loggers:
                 logger_to_update.removeHandler(handler)
 
 
-def syslog(logger_to_update=logger, facility=SysLogHandler.LOG_USER, disableStderrLogger=True):
+def syslog(logger_to_update=logger, facility=SysLogHandler.LOG_USER, disable_stream_loggers=True):
     """
     Setup logging to syslog and disable other internal loggers
     :param logger_to_update: the logger to enable syslog logging for
     :param facility: syslog facility to log to
-    :param disableStderrLogger: should the default stderr logger be disabled? defaults to True
+    :param disable_stream_loggers: should the default stream loggers(stderr/stdout) be disabled? defaults to `True`
     :return the new SysLogHandler, which can be modified externally (e.g. for custom log level)
     """
     # remove internal loggers
-    __remove_internal_loggers(logger_to_update, disableStderrLogger)
+    __remove_internal_loggers(logger_to_update, disable_stream_loggers)
 
     # Setup logzero to only use the syslog handler with the specified facility
     syslog_handler = SysLogHandler(facility=facility)
@@ -536,6 +540,9 @@ def log_function_call(func):
         return func(*args, **kwargs)
     return wrap
 
+
+# Initially setup the default logger
+reset_default_logger()
 
 if __name__ == "__main__":
     _logger = setup_logger()

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -153,7 +153,7 @@ def setup_logger(name=__name__, logfile=None, level=DEBUG, formatter=None, maxBy
                 _logger.removeHandler(handler)
                 continue
             elif isinstance(handler, logging.StreamHandler):
-                if log_stream is None or log_stream not in std_stream_handler.stream.name:
+                if log_stream is None or (std_stream_handler and log_stream not in std_stream_handler.stream.name):
                     # remove the std handler (stream_handler) if disabled, or if there is a stream(err/out) mismatch
                     _logger.removeHandler(handler)
                     continue

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -175,6 +175,9 @@ def setup_logger(name=__name__, logfile=None, level=DEBUG, formatter=None, maxBy
         _logger.addHandler(std_stream_handler)
 
     if logfile:
+        # Create the folder for holding the logfile, if it doesn't already exist
+        Path(logfile).parent.mkdir(parents=True, exist_ok=True)
+        
         rotating_filehandler = RotatingFileHandler(filename=logfile, maxBytes=maxBytes, backupCount=backupCount)
         setattr(rotating_filehandler, LOGZERO_INTERNAL_LOGGER_ATTR, True)
         rotating_filehandler.setLevel(fileLoglevel or level)

--- a/logzero/__init__.py
+++ b/logzero/__init__.py
@@ -40,6 +40,7 @@ import sys
 import logging
 from logzero.colors import Fore as ForegroundColors
 from logzero.jsonlogger import JsonFormatter
+from pathlib import Path
 
 from logging.handlers import RotatingFileHandler, SysLogHandler
 from logging import CRITICAL, ERROR, WARNING, WARN, INFO, DEBUG, NOTSET  # noqa: F401
@@ -439,6 +440,9 @@ def logfile(filename, formatter=None, mode='a', maxBytes=0, backupCount=0, encod
     # If no filename supplied, all is done
     if not filename:
         return
+
+    # Create the folder for holding the logfile, if it doesn't already exist
+    Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
     # Now add
     rotating_filehandler = RotatingFileHandler(filename, mode=mode, maxBytes=maxBytes, backupCount=backupCount, encoding=encoding)

--- a/tests/test_logzero.py
+++ b/tests/test_logzero.py
@@ -9,6 +9,7 @@ Tests for `logzero` module.
 import os
 import tempfile
 import logging
+from pathlib import Path
 
 import logzero
 
@@ -20,8 +21,25 @@ def test_write_to_logfile_and_stderr(capsys):
     logzero.reset_default_logger()
     temp = tempfile.NamedTemporaryFile()
 
+    # Try creating a logfile
     try:
         logger = logzero.setup_logger('test_write_to_logfile_and_stderr', logfile=temp.name)
+        logger.info("test log output")
+
+        _out, err = capsys.readouterr()
+        assert " test_logzero:" in err
+        assert err.endswith("test log output\n")
+
+        with open(temp.name) as f:
+            content = f.read()
+            assert " test_logzero:" in content
+            assert content.endswith("test log output\n")
+    finally:
+        temp.close()
+    
+    # Try creating a logfile along with the required parent folder
+    try:
+        logger = logzero.setup_logger('test_write_to_logfile_and_stderr', logfile=Path(f"{temp.name}_folder")/Path(temp.name).name)
         logger.info("test log output")
 
         _out, err = capsys.readouterr()


### PR DESCRIPTION
* Allows conversion of python log levels to [syslog severity levels](https://en.wikipedia.org/wiki/Syslog#Severity_level) in the built-in `LogFormatter`
* Allow [ISO-8601(RFC-3339)](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) date format and [Azure logging](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-retrieve-iot-edge-logs?view=iotedge-2018-06#recommended-logging-format) date format in the built-in `LogFormatter`

**Example 1:**
```python
  import logzero
  
  logger_iso = logzero.setup_logger("iso", formatter=logzero.LogFormatter(datefmt="iso"))
  logger_iso.debug("ISO Date Format")
  ```
  Output: `[D 2022-01-09 15:22:20.460+00:00 <ipython-input-2-3ff20e2c8c6a>:5] ISO Date Format`
<br>

**Example 2:**
```python
logger_azure = logzero.setup_logger("azure", formatter=logzero.LogFormatter(datefmt="azure"))
logger_azure.debug("Azure Date format")
```
Output: `[D 2022-01-09 15:26:19.902 +00:00 <ipython-input-4-05e4cf246476>:2] Azure Date format`
<br>

**Example 3:**
```python
logger_azure = logzero.setup_logger("azure", formatter=logzero.LogFormatter(fmt='%(color)s<%(levelno)s> %(asctime)s [%(levelname)s] %(message)s%(end_color)s',datefmt="azure", syslog_levels=True))
logger_azure.debug("Azure Log format")
```
Output: `<7> 2022-01-09 15:22:20.460 +00:00 [DBG] Azure Log format`